### PR TITLE
Upgrade from older to current

### DIFF
--- a/test/suites/edgexfoundry/main_test.go
+++ b/test/suites/edgexfoundry/main_test.go
@@ -84,7 +84,5 @@ func TestCommon(t *testing.T) {
 		TestSemanticSnapVersion: true,
 	})
 
-	utils.TestRefresh(t, platformSnap, utils.Refresh{
-		TestRefreshServicesAndConfigPaths: true,
-	})
+	utils.TestRefresh(t, platformSnap)
 }

--- a/test/utils/refresh.go
+++ b/test/utils/refresh.go
@@ -2,63 +2,66 @@ package utils
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-type Refresh struct {
-	TestRefreshServicesAndConfigPaths bool
-}
-
-func TestRefresh(t *testing.T, snapName string, conf Refresh) {
+// TestRefresh tests an EdgeX upgrade using snap refresh
+func TestRefresh(t *testing.T, snapName string) {
 	t.Run("refresh", func(t *testing.T) {
-		if conf.TestRefreshServicesAndConfigPaths {
-			testRefresh(t, snapName)
-		}
-	})
-}
-
-func testRefresh(t *testing.T, snapName string) {
-	const refreshChannel = "latest/beta"
-	var refreshRevision string
-
-	t.Cleanup(func() {
 		if LocalSnap != "" {
-			SnapRemove(t, snapName)
-			SnapInstallFromFile(t, LocalSnap)
-		} else {
+			t.Skip("Skip refresh for local snap build")
+		}
+
+		const stableChannel = "latest/stable"
+
+		if ServiceChannel == stableChannel {
+			t.Skipf("Skip refresh on same channel: %s", ServiceChannel)
+		}
+
+		// remove and install the older stable revision
+		SnapRemove(t, snapName)
+		SnapInstallFromStore(t, snapName, stableChannel)
+
+		var refreshRevision string
+
+		t.Cleanup(func() {
 			SnapRemove(t, snapName)
 			SnapInstallFromStore(t, snapName, ServiceChannel)
-		}
-		WaitPlatformOnline(t)
-	})
 
-	originalVersion := SnapVersion(t, snapName)
-	originalRevision := SnapRevision(t, snapName)
+			WaitPlatformOnline(t)
+		})
 
-	t.Run("refresh services", func(t *testing.T) {
-		SnapRefresh(t, snapName, refreshChannel)
-		refreshVersion := SnapVersion(t, snapName)
-		refreshRevision = SnapRevision(t, snapName)
-		WaitPlatformOnline(t)
+		originalVersion := SnapVersion(t, snapName)
+		originalRevision := SnapRevision(t, snapName)
 
-		t.Logf("Successfully upgraded from %s(%s) to %s(%s)",
-			originalVersion, originalRevision, refreshVersion, refreshRevision)
-	})
+		t.Run("check services", func(t *testing.T) {
+			SnapRefresh(t, snapName, ServiceChannel)
+			refreshVersion := SnapVersion(t, snapName)
+			refreshRevision = SnapRevision(t, snapName)
+			WaitPlatformOnline(t)
 
-	t.Run("refresh config paths", func(t *testing.T) {
-		if originalRevision == refreshRevision {
-			t.Skip("Upgraded to the same revision. Skipping test")
-		}
+			t.Logf("Successfully upgraded from %s (%s) to %s (%s)",
+				originalVersion, originalRevision, refreshVersion, refreshRevision)
+		})
 
-		t.Logf("Checking for files with original snap revision %s", originalRevision)
+		t.Run("check config paths", func(t *testing.T) {
+			if originalRevision == refreshRevision {
+				t.Skip("Upgraded to the same revision. Skipping test")
+			}
 
-		// The command should not return error even if nothing is grepped, hence the "|| true"
-		stdout, stderr := exec(t, fmt.Sprintf(`sudo grep -RnI "%s/%s" /var/snap/%s/current || true`,
-			snapName, originalRevision, snapName),
-			true)
-		require.Empty(t, stdout,
-			fmt.Sprintf(`files not upgraded to use "current" symlink in config files:%s`, stdout))
-		require.Empty(t, stderr)
+			t.Logf("Looking for files containing previous snap revision %s", originalRevision)
+
+			// The command should not return error even if nothing is grepped, hence the "|| true"
+			stdout, stderr := exec(t,
+				fmt.Sprintf("sudo grep -RnI '%s/%s' /var/snap/%s/current || true",
+					snapName, originalRevision, snapName),
+				true)
+			require.Empty(t, stdout,
+				"The following files contain revision %s instead of %s or 'current' symlink: %s",
+				originalRevision, refreshRevision, stdout)
+			require.Empty(t, stderr)
+		})
 	})
 }


### PR DESCRIPTION
- Improved logging.
- Set refresh to always upgrade from stable to current.
- Skip test for local snap builds.

The reason for skipping the test for local builds is because a refresh isn't possible from a store installed snap to a locally built one. The opposite is possible.